### PR TITLE
The Great GPU Rewrite™

### DIFF
--- a/graphics/GPU.cpp
+++ b/graphics/GPU.cpp
@@ -220,6 +220,9 @@ void GPU::render(uint32_t clocks) {
 								bool flip_x   = (SPRT_DATA_ADDR[3] >> 5) & 0x01;
 								bool palette  = (SPRT_DATA_ADDR[3] >> 4) & 0x01;
 
+								// if this is a double height sprite with a y flip, swap upper and lower tiles
+								if (flip_y && (GPU_REG_LCD_CONTROL & SIZE_OBJ)) spr_tile_id += ((y - 8 < spr_y) ? 1 : -1);
+
 								uint16_t* TILE_ADDR = (uint16_t *)(TILES_SPRITES + spr_tile_id * 16);
 
 								spr_y -= 16; //convert to top

--- a/graphics/GPU.cpp
+++ b/graphics/GPU.cpp
@@ -241,7 +241,7 @@ void GPU::render(uint32_t clocks) {
 								uint8_t C = (((palette) ? GPU_REG_PALETTE_S1 : GPU_REG_PALETTE_S0) >> (B << 1)) & 0x03;
 
 								// if sprite priority mode, skip write check
-								if (priority && (WINDOW_MEMORY[window_pos] == PALETTE[GPU_REG_PALETTE_BG >> 6]));
+								if (priority && (WINDOW_MEMORY[window_pos] != PALETTE[GPU_REG_PALETTE_BG & 0x03]));
 								
 								// if not colour 0, write new pixel data
 								else if (B) {

--- a/graphics/GPU.cpp
+++ b/graphics/GPU.cpp
@@ -93,30 +93,24 @@ void GPU::render(uint32_t clocks) {
 
 						{
 
-						uint8_t last_pos = 0;
+						uint8_t pos = 0;
 						uint8_t* SPRT_DATA_ADDR;
 
 						/* Search through sprite list and find items that fall on the given line */
-						for (uint8_t i = 0; i < 10; i++) {
+						for (uint8_t i = 0; ((i < 40) && (pos < 10)); i++) {
+							SPRT_DATA_ADDR = (uint8_t *)(OAM + i);
 
-							for (uint8_t j = last_pos; j < 40; j++) {
+							int16_t spr_y = (int16_t) SPRT_DATA_ADDR[0];
+							int16_t spr_x = (int16_t) SPRT_DATA_ADDR[1];
 
-								SPRT_DATA_ADDR = (uint8_t *)(OAM + j);
+							spr_y -= 16; //convert to top
+							spr_x -= 8; //convert to left
 
-								int16_t spr_y = ((int16_t) SPRT_DATA_ADDR[0]);
-								int16_t spr_x = ((int16_t) SPRT_DATA_ADDR[1]);
-
-								spr_y -= 16; //convert to top
-								spr_x -= 8; //convert to left
-
-								if ((spr_y <= GPU_REG_LCDCUR_Y) && (spr_y + ((GPU_REG_LCD_CONTROL & SIZE_OBJ) ? 16 : 8) > GPU_REG_LCDCUR_Y)) { //if sprite appears on this line
-									OAM_SPR_IDX[i] = j; //add tile ID
-									OAM_SPR_XPOS[i] = spr_x; //add sprite's xpos
-									last_pos = j + 1; //add next position to check
-									break;
-								}								
+							if ((spr_y <= GPU_REG_LCDCUR_Y) && (spr_y + ((GPU_REG_LCD_CONTROL & SIZE_OBJ) ? 16 : 8) > GPU_REG_LCDCUR_Y)) { //if sprite appears on this line
+								OAM_SPR_IDX[pos] = i; //add tile ID
+								OAM_SPR_XPOS[pos] = spr_x; //add sprite's xpos
+								pos++;
 							}
-
 						}
 
 						}
@@ -215,6 +209,7 @@ void GPU::render(uint32_t clocks) {
 						if (GPU_REG_LCD_CONTROL & ENABLE_OBJ) {
 
 							uint8_t index = 0xFF;
+							uint16_t window_pos = (x + y * SCREEN_WIDTH);
 
 							for (uint8_t i = 0; i < 10; i++) {
 								if (OAM_SPR_IDX[i] == 0xFF) break;
@@ -260,8 +255,11 @@ void GPU::render(uint32_t clocks) {
 							// palette remapping
 							uint8_t C = (((palette) ? GPU_REG_PALETTE_S1 : GPU_REG_PALETTE_S0) >> (B << 1)) & 0x03;
 
+							// if sprite priority mode, skip write check
+							if (priority && WINDOW_MEMORY[window_pos] == PALETTE[GPU_REG_PALETTE_BG >> 6]);
+							
 							// write new pixel data
-							if (C) WINDOW_MEMORY[x + y * SCREEN_WIDTH] = PALETTE[C];
+							else if (C) WINDOW_MEMORY[window_pos] = PALETTE[C];
 						}
 						}
 						COMPLETED_CLOCKS++;

--- a/graphics/GPU.cpp
+++ b/graphics/GPU.cpp
@@ -100,11 +100,8 @@ void GPU::render(uint32_t clocks) {
 						for (uint8_t i = 0; ((i < 40) && (pos < 10)); i++) {
 							SPRT_DATA_ADDR = (uint8_t *)(OAM + i);
 
-							int16_t spr_y = (int16_t) SPRT_DATA_ADDR[0];
-							int16_t spr_x = (int16_t) SPRT_DATA_ADDR[1];
-
-							spr_y -= 16; //convert to top
-							spr_x -= 8; //convert to left
+							int16_t spr_y = ((int16_t) SPRT_DATA_ADDR[0]) - 16;
+							uint8_t spr_x = SPRT_DATA_ADDR[1] - 8;
 
 							if ((spr_y <= GPU_REG_LCDCUR_Y) && (spr_y + ((GPU_REG_LCD_CONTROL & SIZE_OBJ) ? 16 : 8) > GPU_REG_LCDCUR_Y)) { //if sprite appears on this line
 								OAM_SPR_IDX[pos] = i; //add tile ID
@@ -160,7 +157,7 @@ void GPU::render(uint32_t clocks) {
 							uint16_t A = TILE_ADDR[bg_sy % 8];
 
 							// shuffle bits
-							uint8_t B = ((A >> (15 - (bg_sx % 8)) & 0x01) + (((A >> (7 - (bg_sx % 8))) & 0x01) << 1));
+							uint8_t B = (((A >> (7 - (bg_sx % 8))) & 0x01) + ((A >> (15 - (bg_sx % 8)) & 0x01) << 1));
 
 							// palette remapping
 							uint8_t C = (GPU_REG_PALETTE_BG >> (B << 1)) & 0x03;
@@ -193,7 +190,7 @@ void GPU::render(uint32_t clocks) {
 									uint16_t A = TILE_ADDR[win_y % 8];
 
 									// shuffle bits
-									uint8_t B = ((A >> (15 - (win_x % 8)) & 0x01) + (((A >> (7 - (win_x % 8))) & 0x01) << 1));
+									uint8_t B = (((A >> (7 - (win_x % 8))) & 0x01) + ((A >> (15 - (win_x % 8)) & 0x01) << 1));
 
 									// palette remapping
 									uint8_t C = (GPU_REG_PALETTE_BG >> (B << 1)) & 0x03;
@@ -250,7 +247,7 @@ void GPU::render(uint32_t clocks) {
 							uint16_t ux = (flip_x ? (7 - spr_nx) : spr_nx);
 
 							// shuffle bits
-							uint8_t B = ((A >> (15 - ux) & 0x01) + (((A >> (7 - ux)) & 0x01) << 1));
+							uint8_t B = (((A >> (7 - ux)) & 0x01) + ((A >> (15 - ux) & 0x01) << 1));
 
 							// palette remapping
 							uint8_t C = (((palette) ? GPU_REG_PALETTE_S1 : GPU_REG_PALETTE_S0) >> (B << 1)) & 0x03;

--- a/graphics/GPU.h
+++ b/graphics/GPU.h
@@ -115,15 +115,6 @@ class GPU {
 		/* FUNCTIONS */ 
 		void clear(); // Write value to display to 'turn it off'
 
-		/* Render sprites to buffer */
-		void draw_sprites();
-
-		/* Render window to buffer */
-		void draw_window();
-
-		/* Render background tiles to buffer */
-		void draw_bg();
-
 		// const uint32_t PALETTE[4] = {0xFFFFFFFF, 0xFFA8A8A8, 0xFF545454, 0xFF000000}; //b&w
 		const uint32_t PALETTE[4] = {0xFF879457, 0xFF547659, 0xFF3B584C, 0xFF223A32}; //awful... err... authentic green
 

--- a/graphics/GPU.h
+++ b/graphics/GPU.h
@@ -4,21 +4,18 @@ NICK
 2019
 */
 
+#ifndef GB_GPU_H
+#define GB_GPU_H
+
 #include <cstdint>	//standard number formats
 #include <string.h>	//memset
 #include <iostream> //malloc
 
-#include <iomanip>
-
-#define BUFFER_W_H 			0x20
-#define TILE_SIZE 			0x10
 #define KB 					0x400
-#define SCREEN_OFF_COLOUR 	0xFFDEDEDE
+#define SCREEN_OFF_COLOUR 	0x94
 
-#define OAM_DELAY 		80
-#define TRANSFER_DELAY 	172
-#define H_BLANK_DELAY 	204
-#define V_BLANK_DELAY 	4560
+#define OAM_DELAY 			80
+#define LINE_CLOCK_WIDTH	456
 
 /* LCDC BITS */
 #define ENABLE_LCD_DISPLAY 		0x80 // Display toggle
@@ -29,13 +26,6 @@ NICK
 #define SIZE_OBJ 				0x04 // Sprite mode (8x8 or 8x16)
 #define ENABLE_OBJ 				0x02 // Sprite toggle
 #define ENABLE_BG_WIN_DISPLAY 	0x01 // Combined background & window toggle
-
-/* TODO: 
-	BIT 6 - Might be required
-	BIT 4 - Might be required
-	BIT 3 - Might be required
-	BIT 2 - Unlikely to be required
-*/
 
 /* LCD STATUS BITS */
 #define INTR_LYC_EQ_LY 	0x40 // LY_CMP register check toggle
@@ -54,12 +44,6 @@ NICK
 #define SCREEN_WIDTH	160
 #define SCREEN_HEIGHT	144
 
-/* TODO:
-	ALL BITS
-*/
-
-#ifndef GB_GPU_H
-#define GB_GPU_H
 
 // The type of an interrupt handler function pointer
 typedef void (*gpu_interrupt_handler_t)(void *);
@@ -89,11 +73,6 @@ class GPU {
 		uint8_t* WINDOW_MAP;		// Start of window map
 		uint32_t* OAM; 				// Start of OAM (sprite metadata)
 
-		/* BUFFERS */
-		uint32_t* BG_BUFFER;
-		uint32_t* WINDOW_BUFFER;
-		uint32_t* SPRITE_BUFFER;
-
 		/* SDL_WINDOW RENDER DESTINATION */
 		uint32_t* WINDOW_MEMORY;
 
@@ -102,13 +81,14 @@ class GPU {
 
 		/* OAM SPRITE LINE DATA */
 		uint8_t OAM_SPR_IDX[10] = {};
-		uint8_t OAM_SPR_XPOS[10] = {};
+		int16_t OAM_SPR_XPOS[10] = {};
 
 		/* POINTER TO INTERRUPT ROUTINES */
 		gpu_interrupt_handler_t F_INTR_LYC;
 		gpu_interrupt_handler_t F_INTR_OAM;
 		gpu_interrupt_handler_t F_INTR_HBL;
 		gpu_interrupt_handler_t F_INTR_VBL;
+
 		/* Pass this to interrupt functions */
 		void *INTR_FUNC_CONTEXT = 0;
 

--- a/graphics/GPU.h
+++ b/graphics/GPU.h
@@ -115,7 +115,7 @@ class GPU {
 		/* FUNCTIONS */ 
 		void clear(); // Write value to display to 'turn it off'
 
-		// const uint32_t PALETTE[4] = {0xFFFFFFFF, 0xFFA8A8A8, 0xFF545454, 0xFF000000}; //b&w
+		// const uint32_t PALETTE[4] = {0xFFFFFFFF, 0xFFB0B0B0, 0xFF686868, 0xFF000000}; //b&w
 		const uint32_t PALETTE[4] = {0xFF879457, 0xFF547659, 0xFF3B584C, 0xFF223A32}; //awful... err... authentic green
 
 	public:

--- a/graphics/GPU.h
+++ b/graphics/GPU.h
@@ -101,7 +101,8 @@ class GPU {
 		uint32_t POSITION = 0;
 
 		/* OAM SPRITE LINE DATA */
-		uint8_t OAM_SPR_DATA[10] = {};
+		uint8_t OAM_SPR_IDX[10] = {};
+		uint8_t OAM_SPR_XPOS[10] = {};
 
 		/* POINTER TO INTERRUPT ROUTINES */
 		gpu_interrupt_handler_t F_INTR_LYC;

--- a/graphics/GPU.h
+++ b/graphics/GPU.h
@@ -100,6 +100,9 @@ class GPU {
 		/* TIMING LIST */
 		uint32_t POSITION = 0;
 
+		/* OAM SPRITE LINE DATA */
+		uint8_t OAM_SPR_DATA[10] = {};
+
 		/* POINTER TO INTERRUPT ROUTINES */
 		gpu_interrupt_handler_t F_INTR_LYC;
 		gpu_interrupt_handler_t F_INTR_OAM;
@@ -137,7 +140,7 @@ class GPU {
 		/* Redraw all layers */
 		void redraw();
 
-		/* Simulate [clocks] cycles of the PPU*/
+		/* Simulate [clocks] cycles of the PPU */
 		void render(uint32_t clocks);
 
 		/* Return VRAM */

--- a/meta/meta.rc
+++ b/meta/meta.rc
@@ -1,19 +1,19 @@
 1 VERSIONINFO
-FILEVERSION     1,1,0,0
-PRODUCTVERSION  1,1,0,0
+FILEVERSION     1,2,0,0
+PRODUCTVERSION  1,2,0,0
 BEGIN
   BLOCK "StringFileInfo"
   BEGIN
     BLOCK "040904E4"
     BEGIN
-      VALUE "CompanyName", "TEAM BAYFIELD EMULATION"
+      VALUE "CompanyName", "BAYFIELD EMULATION GROUP"
       VALUE "FileDescription", "Bayfield Gameboy Emulator"
-      VALUE "FileVersion", "1.1.0"
+      VALUE "FileVersion", "1.2.0"
       VALUE "InternalName", "bayfield_gb"
-      VALUE "LegalCopyright", "TEAM BAYFIELD EMULATION"
+      VALUE "LegalCopyright", "BAYFIELD EMULATION GROUP"
       VALUE "OriginalFilename", "Bayfield.exe"
       VALUE "ProductName", "BAYFIELD EMULATOR"
-      VALUE "ProductVersion", "1.1.0"
+      VALUE "ProductVersion", "1.2.0"
     END
   END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
Games should now be drawn 100% accurately, barring bugs I did not find in my testing. No shortcuts are taken anymore. The call to `redraw()` is now just a stub, it should be cleaned up in the future.

1. On the first clock of *OAM*, an array of up to 10 sprites is populated with sprites present on the line. Subsequent clocks are idled (OAM is locked, so nothing can change during the rest of the period anyway).

1. Every clock during *Pixel Transfer*, a single pixel is calculated for background, window, and (possibly multiple) sprite indices.


Also some fixes:

1. Fixed palette bug - high and low index bit were swapped.

1. Overlapping sprites will now draw correctly.

1. Sprite priority should work, but I'm not 100% sure any of the games I test with actually use it - it appears to be a rarely used feature.
